### PR TITLE
feat: sha input

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ jobs:
 | `github-token` | ❌        | `github.token` | The GitHub token used to call the GitHub API    |
 | `timeout`      | ❌        | `30000`        | timeout before we stop trying (in milliseconds) |
 | `delay`        | ❌        | `5000`         | delay between status checks (in milliseconds)   |
-| `sha`          | ❌        | `github.sha`   | Git SHA, if it's different from `github.sha`    |
 
 ----
 > Author: [Ahmad Nassri](https://www.ahmadnassri.com/) &bull;

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ jobs:
 | `github-token` | ❌        | `github.token` | The GitHub token used to call the GitHub API    |
 | `timeout`      | ❌        | `30000`        | timeout before we stop trying (in milliseconds) |
 | `delay`        | ❌        | `5000`         | delay between status checks (in milliseconds)   |
+| `sha`          | ❌        | `github.sha`   | Git SHA, if it's different from `github.sha`    |
 
 ----
 > Author: [Ahmad Nassri](https://www.ahmadnassri.com/) &bull;

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Workflow Run Wait Temp
+name: Workflow Run Wait
 description: wait for all `workflow_run` required workflows to be successful; used for tests, don't rely on it
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Workflow Run Wait
-description: wait for all `workflow_run` required workflows to be successful
+name: Workflow Run Wait Temp
+description: wait for all `workflow_run` required workflows to be successful; used for tests, don't rely on it
 
 branding:
   color: blue
@@ -17,6 +17,10 @@ inputs:
   delay:
     description: delay between status checks (in milliseconds)
     default: 5000
+
+  sha:
+    description: SHA to use (defaults to github.sha)
+    default: ${{ github.sha }}
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Workflow Run Wait
-description: wait for all `workflow_run` required workflows to be successful; used for tests, don't rely on it
+description: wait for all `workflow_run` required workflows to be successful
 
 branding:
   color: blue

--- a/action/index.js
+++ b/action/index.js
@@ -17,7 +17,8 @@ if (github.context.eventName !== 'workflow_run') {
 const inputs = {
   token: core.getInput('github-token', { required: true }),
   delay: Number(core.getInput('delay', { required: true })),
-  timeout: Number(core.getInput('timeout', { required: true }))
+  timeout: Number(core.getInput('timeout', { required: true })),
+  sha: core.getInput('sha', { required: true }),
 }
 
 // error handler

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -11,14 +11,14 @@ import workflows from './workflows.js'
 // sleep function
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-export default async function ({ token, delay, timeout }) {
+export default async function ({ token, delay, timeout, sha }) {
   let timer = 0
 
   // init octokit
   const octokit = github.getOctokit(token)
 
   // extract sha
-  const { sha, ref, runId: run_id } = github.context
+  const { ctx_sha, ref, runId: run_id } = github.context
 
   core.debug(`sha: ${sha}`)
   core.debug(`run.id: ${run_id}`)
@@ -38,7 +38,7 @@ export default async function ({ token, delay, timeout }) {
   const dependencies = await workflows({ octokit, ref, workflow_id })
 
   // check runs
-  let result = await runs(octokit, dependencies)
+  let result = await runs(octokit, dependencies, sha)
 
   if (result.length === 0) {
     core.info('no runs found for this workflow\'s dependencies')
@@ -72,7 +72,7 @@ export default async function ({ token, delay, timeout }) {
     await sleep(delay)
 
     // get the data again
-    result = await runs(octokit, dependencies)
+    result = await runs(octokit, dependencies, sha)
   }
 
   for (const run of result) {

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -18,7 +18,7 @@ export default async function ({ token, delay, timeout, sha }) {
   const octokit = github.getOctokit(token)
 
   // extract sha
-  const { ctx_sha, ref, runId: run_id } = github.context
+  const { ref, runId: run_id } = github.context
 
   core.debug(`sha: ${sha}`)
   core.debug(`run.id: ${run_id}`)

--- a/action/lib/runs.js
+++ b/action/lib/runs.js
@@ -5,10 +5,7 @@ import { inspect } from 'util'
 import core from '@actions/core'
 import github from '@actions/github'
 
-export default async function (octokit, dependencies) {
-  // extract sha
-  const { sha } = github.context
-
+export default async function (octokit, dependencies, sha) {
   const { data: { workflow_runs } } = await octokit.request('GET /repos/{owner}/{repo}/actions/runs', { // eslint-disable-line camelcase
     ...github.context.repo
   })

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,3 +68,4 @@ jobs:
 | `github-token` | ❌        | `github.token` | The GitHub token used to call the GitHub API    |
 | `timeout`      | ❌        | `30000`        | timeout before we stop trying (in milliseconds) |
 | `delay`        | ❌        | `5000`         | delay between status checks (in milliseconds)   |
+| `sha`          | ❌        | `github.sha`   | Git SHA, if it's different from `github.sha`    |


### PR DESCRIPTION
When the head SHA is different from the SHA that triggered the workflows (say, because there's a workflow that bumps the release and commits after the merge), the action will fail to find the upstream workflows; this adds a parameter called `sha` which can be set to `${{ github.event.workflow_run.head_commit.id }}`.