### PR TITLE
Deduplication errors out if the provided SHA is different from top commit

### DIFF
--- a/action/lib/deduplicate.js
+++ b/action/lib/deduplicate.js
@@ -7,13 +7,15 @@ import { inspect } from 'util'
 import core from '@actions/core'
 import github from '@actions/github'
 
-export default async function ({ octokit, workflow_id, run_id, sha }) {
+export default async function ({ octokit, workflow_id, run_id }) {
   // get current run of this workflow
   const { data: { workflow_runs } } = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
     ...github.context.repo,
     per_page: 100,
     workflow_id
   })
+
+  const { sha } = github.context
 
   // filter and sort
   const cancellable = workflow_runs

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -32,7 +32,7 @@ export default async function ({ token, delay, timeout, sha, ignore }) {
   core.debug(`workflow_id: ${workflow_id}`)
 
   // don't run this workflow twice for the same commit
-  await deduplicate({ octokit, workflow_id, run_id, sha })
+  await deduplicate({ octokit, workflow_id, run_id })
 
   // find all the dependencies
   const dependencies = await workflows({ octokit, ref, workflow_id })


### PR DESCRIPTION
Basically, it doesn't find any runs of the workflow that called the action, so it explodes:

```
found 0 cancellable runs of workflow #[number]
Error: Cannot read property 'id' of undefined
TypeError: Cannot read property 'id' of undefined
    at default (file:///action/lib/deduplicate.js:43:38)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async default (file:///action/lib/index.js:35:3)
    at async file:///action/index.js:37:1
```
This fixes the issue by making the deduplication always use the latest commit SHA (the one from the github context).

I didn't get to test if the rest of the deduplication works because of this, but in my ~flailing~ test version the most reliable way to deduplicate proved to be cancelling the current workflow if there is any other running or successful workflow with the same id and hash (if the oldest run detects that all upstreams finished and completes while the current run is still waiting in queue there will be duplicate runs).