### PR TITLE
Include completed successful runs when deduplicating

### DIFF
--- a/action/lib/deduplicate.js
+++ b/action/lib/deduplicate.js
@@ -19,8 +19,6 @@ export default async function ({ octokit, workflow_id, run_id }) {
 
   // filter and sort
   const cancellable = workflow_runs
-    // filter to relevant runs
-    .filter(run => ['in_progress', 'queued', 'completed'].includes(run.status))
     // filter to only runs for the same commit
     .filter(run => run.head_sha === sha)
     // filter out unsuccessful completed runs (cancelled / failed)

--- a/action/lib/deduplicate.js
+++ b/action/lib/deduplicate.js
@@ -7,13 +7,15 @@ import { inspect } from 'util'
 import core from '@actions/core'
 import github from '@actions/github'
 
-export default async function ({ octokit, workflow_id, run_id, sha }) {
+export default async function ({ octokit, workflow_id, run_id }) {
   // get current run of this workflow
   const { data: { workflow_runs } } = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
     ...github.context.repo,
     per_page: 100,
     workflow_id
   })
+
+  const { sha } = github.context
 
   // filter and sort
   const cancellable = workflow_runs

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -32,7 +32,7 @@ export default async function ({ token, delay, timeout, sha, ignore }) {
   core.debug(`workflow_id: ${workflow_id}`)
 
   // don't run this workflow twice for the same commit
-  await deduplicate({ octokit, workflow_id, run_id, sha })
+  await deduplicate({ octokit, workflow_id, run_id })
 
   // find all the dependencies
   const dependencies = await workflows({ octokit, ref, workflow_id })


### PR DESCRIPTION
This fixes the issue from https://github.com/ahmadnassri/action-workflow-run-wait/pull/3#issuecomment-784334866:
![Screenshot from 2021-02-23 18-33-02](https://user-images.githubusercontent.com/183823/108894250-f741cd00-7609-11eb-98f6-5ad58f297244.png)

Basically, if you have 3 (or more) upstream workflows, each of them will trigger a run of the workflow calling this action (let's call it "Deploy", as in the image); the current code looks for other in progress or queued runs of the same workflow for the same hash as the current one, and cancels all but the first started one. 

This creates a race condition, because:
* when the last of the upstream workflows finishes, it fires up a Deploy workflow, which gets queued for a random amount of time, depending on runner availability 
* in the mean time, the oldest Deploy figures out it can move forward because it checks every 5 seconds by default, moves on and finishes (in this case it fires a webhook payload to a Jenkins machine, but it could be anything that doesn't take much time)
* when the last started Deploy finally gets to run, it looks for other runs in progress or queued, figures out it's alone and happily fires up a second time, because all conditions are met

This PR adds completed successful workflows of the same SHA as the current run to the list of cancellable runs, allowing the action to cancel the current workflow if it already ran successfully for the same commit before.